### PR TITLE
Mufasa: The Lion King (.𝟸𝟶𝟸𝟺.) +𝙵𝚞𝚕𝚕𝙼𝚘𝚟𝚒𝚎! 𝙳𝚘𝚠𝚗𝚕𝚘𝚊𝚍 𝙵𝚛𝚎𝚎 𝙾𝚗𝚕𝚒𝚗𝚎 𝙾𝚗 𝚂𝚝𝚛𝚎𝚊𝚖𝚒𝚗𝚐 𝟽𝟸𝟶𝚙, 𝟺𝟾𝟶𝚙 𝙷𝙳

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
 # -Mufasa-The-Lion-King-.-.-
  Mufasa: The Lion King (.𝟸𝟶𝟸𝟺.) +𝙵𝚞𝚕𝚕𝙼𝚘𝚟𝚒𝚎! 𝙳𝚘𝚠𝚗𝚕𝚘𝚊𝚍 𝙵𝚛𝚎𝚎 𝙾𝚗𝚕𝚒𝚗𝚎 𝙾𝚗 𝚂𝚝𝚛𝚎𝚊𝚖𝚒𝚗𝚐 𝟽𝟸𝟶𝚙, 𝟺𝟾𝟶𝚙 𝙷𝙳
+
+ 26 Sec ago - Still 𝙽ow Mufasa: The Lion King are options for Downl𝚘ading or Watching Mufasa: The Lion King Strea𝚖ing the Ful𝚕 Mo𝚟ie 𝙾nl𝚒ne for 𝙵r𝚎e on 123Mo𝚟ies & 𝚁edd𝙸t, including Mufasa: The Lion King to Watch Mufasa: The Lion King latest supernatural comedy horror Mo𝚟ie Mufasa: The Lion King at home. Mufasa: The Lion King Mufasa: The Lion King (2024 available to 𝚂trea𝙼? Is Watching Mufasa: The Lion King on Peacock, HBO Max, 𝙽etflix or Disney Plus? Yes, we have found an authentic Strea𝚖ing option/service.
+
+➤ ►🌍📺📱👉 Mufasa: The Lion King (Mufasa: The Lion King (2024) Ful𝚕 Mo𝚟ie
+
+➤ ►🌍📺📱👉 Mufasa: The Lion King (Mufasa: The Lion King (2024) Ful𝚕 Mo𝚟ie
+
+➤ ►🌍📺📱👉 WaTch Mufasa: The Lion King (Mufasa: The Lion King (2024) Ful𝚕 Mo𝚟ie Downl𝚘ad
+
+
+
+
+
+
+Wondering how to Watch Mufasa: The Lion King 𝙾nl𝚒ne? We have all of the details on the Latest English and Hindi Sub Mo𝚟ies, from showtimes to Strea𝚖ing info.
+
+Get ready to add another Mufasa: The Lion King Mo𝚟ie to your queue! Four years after Mufasa: The Lion King hit theaters, it’s finally getting a sequel with Mufasa: The Lion King. The Latest English and Hindi Sub Mo𝚟ies follows Latest English and Hindi Sub Mo𝚟ies and his foster siblings as they turn into superheroes upon saying the word, “Mufasa: The Lion King” In the 130-minute 𝙵ilm, the group must stop the Daughters of Mufasa: The Lion King from using a weapon that could destroy the world.
+
+Mufasa: The Lion King Mufasa: The Lion King review
+
+Mufasa: The Lion King Mo𝚟ie review
+
+Mufasa: The Lion King review
+
+Mufasa: The Lion King reviews
+
+Mufasa: The Lion King Mo𝚟ie rating
+
+Mufasa: The Lion King rating
+
+Mufasa: The Lion King Mo𝚟ie release date
+
+Mufasa: The Lion King review
+
+Mufasa: The Lion King reviews
+
+Mufasa: The Lion King rating
+
+Mufasa: The Lion King Mo𝚟ie review
+
+Mufasa: The Lion King box office collection
+
+So wMufasa: The Lion King can you Watch Mufasa: The Lion King? Is it on HBO Max? What about 𝙽etflix? Mufasa: The Lion King’s how to Watch the Mufasa: The Lion King epic starring Mufasa: The Lion King (2024 Latest English and Hindi Sub Mo𝚟ies.
+
+Is Mufasa coming in 2024?
+
+Release. Mufasa: The Lion King premiered at the Dolby Theatre in Los Angeles on December 9, 2024, and was released in the United States on December 20, 2024. It was previously scheduled for release on July 5, 2024, but was delayed to its current date due to the 2023 SAG-AFTRA strike.
+
+Where can we watch Mufasa?
+
+"Mufasa: The Lion King" is now in theaters. Mufasa: The Lion King will be available for streaming on Disney+ at a later date. Fans can expect the live-action film to arrive on Disney's streaming service approximately three months after its theatrical debut, likely in March 2025.
+
+Are they making a movie about Mufasa?
+
+It's time I tell you a story a story of a c not much bigger than you so just to be clear we're not in this story there's a lot of stories with all of us tell one of those long before they became
+
+Is there an end scene in Mufasa?
+
+Mufasa's story has been narrated by Rafiki, with the Mandrill telling it to Simba's daughter, Kiara (Blue Ivy Carter). The film's final scene has Simba coming home and introducing her to their new cub, her baby brother, Kion. Thus, it makes sense that Mufasa doesn't need a post-credits or a mid-credits scene.
+
+Were Mufasa and Scar real brothers?
+
+Growing up, we always assumed that Scar and Mufasa were brothers, and therefore, Scar was Simba's uncle. It's not something we ever questioned. But it's turns out we had the links between The Lion King characters all wrong. They were members of the same pride but they were never meant to be blood relatives.
+
+Will there be a lion King 2 movie?
+
+Will Mufasa be on Netflix?
+
+As per a report by Decider, 'Mufasa: The Lion King' has fewer chances to be streamed on Netflix as the film is produced by Disney. This fact makes it quite clear that 'Mufasa: The Lion King' will be streaming on Disney Plus Hotstar as it's from their home production.
+
+Did Mufasa love Simba?
+
+Mufasa loved his son very much, and was extremely protective of him as a result, immediately coming to his rescue whenever he is in danger.
+
+What happened to Mufasa after he died in Lion King?
+
+What he thinks happened is that the hyenas ate Mufasa's body and then gave Scar the bones. Later, when Scar falls, they eat him too. The same fate befalling two brothers. Which, as he points out, is very Shakespearean as well.
+
+What runs over Mufasa?
+
+In the first film, the wildebeests stampede to the right when Mufasa falls to his death.
+
+When Is Mufasa: The Lion King Release Date?
+
+Yes, Mufasa: The Lion King will be released exclusively in theaters on June 28, Mufasa: The Lion King (2024. Originally, the Mo𝚟ie was expected to be released on June 28, Mufasa: The Lion King (2024, but was then pushed to November 4, Mufasa: The Lion King (2024, and again to June 28, Mufasa: The Lion King (2024, with these delays ultimately being caused by the COVID-19 pandemic. Further delays also took place, but it looks like this final date will be the one to stick.
+
+WMufasa: The Lion King To Watch Mufasa: The Lion King:
+
+𝙰𝚜 𝚘𝚏 𝙽𝚘𝚠, 𝚝𝚑𝚎 𝚘𝚗𝚕𝚢 𝚙𝚕𝚊𝚌𝚎 𝚝𝚘 𝚆𝚊𝚝𝚌𝚑 Mufasa: The Lion King 𝚒𝚜 𝚝𝚘 𝚐𝚘 𝚝𝚘 𝚊 𝙼𝚘𝚅𝚒𝚎 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚠𝚑𝚎𝚗 𝚒𝚝 𝚍𝚛𝚘𝚙𝚜 𝚘𝚗 𝙵𝚛𝚒𝚍𝚊𝚢, June 28. Mufasa: The Lion King (2024 Watch 𝙽ow: Mufasa: The Lion King 𝙾nl𝚒ne 𝙵r𝚎e
+
+𝚈𝚘𝚞 𝚌𝚊𝚗 𝚏𝚒𝚗𝚍 𝚊 𝚕𝚘𝚌𝚊𝚕 𝚜𝚑𝚘𝚠𝚒𝚗𝚐 𝚘𝚗 𝙵𝚊𝚗𝚍𝚊𝚗𝚐𝚘. 𝙾𝚝𝚑𝚎𝚛 𝚝𝚑𝚊𝚗 𝚝𝚑𝚊𝚝, 𝚢𝚘𝚞 𝚠𝚒𝚕𝚕 𝚑𝚊𝚟𝚎 𝚝𝚘 𝚠𝚊𝚒𝚝 𝚏𝚘𝚛 𝚒𝚝 𝚝𝚘 𝚋𝚎𝚌𝚘𝚖𝚎 𝚊𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 𝚝𝚘 𝚛𝚎𝚗𝚝 𝚘𝚛 𝚙𝚞𝚛𝚌𝚑𝚊𝚜𝚎 𝚘𝚗 𝚍𝚒𝚐𝚒𝚝𝚊𝚕 𝚙𝚕𝚊𝚝𝚏𝚘𝚛𝚖𝚜 𝚕𝚒𝚔𝚎 𝙿𝚛𝚒𝚖𝚎 𝚅𝚒𝚍𝚎𝚘, 𝙰𝚙𝚙𝚕𝚎, 𝚊𝚗𝚍 𝚅𝚞𝚍𝚞 𝚘𝚛 𝚂𝚝𝚛𝚎𝚊𝙼 𝚘𝚗 𝙷𝙱𝙾 𝙼𝚊𝚡. 𝚁𝚎𝚊𝚍 𝚘𝚗 𝚏𝚘𝚛 𝚖𝚘𝚛𝚎 𝚒𝚗𝚏𝚘𝚛𝚖𝚊𝚝𝚒𝚘𝚗.
+
+Is Mufasa: The Lion King 𝙰𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 for Strea𝚖ing 𝙾nl𝚒ne?
+
+𝚁𝚒𝚐𝚑𝚝 𝙽𝚘𝚠, 𝚝𝚑𝚎𝚛𝚎 𝚊𝚛𝚎 𝚌𝚞𝚛𝚛𝚎𝚗𝚝𝚕𝚢 𝚗𝚘 𝚌𝚘𝚗𝚏𝚒𝚛𝚖𝚎𝚍 𝚙𝚕𝚊𝚗𝚜 𝚏𝚘𝚛 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 Mufasa: The Lion King. 𝙰𝚜 𝚖𝚘𝚛𝚎 𝚌𝚒𝚗𝚎𝚖𝚊𝚜 𝚘𝚙𝚎𝚗 𝚞𝚙 𝚊𝚗𝚍 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚊𝚝𝚝𝚎𝚗𝚍𝚊𝚗𝚌𝚎 𝚌𝚘𝚗𝚝𝚒𝚗𝚞𝚎𝚜 𝚝𝚘 𝚛𝚒𝚜𝚎 𝚙𝚘𝚜𝚝-𝚙𝚊𝚗𝚍𝚎𝚖𝚒𝚌, 𝚜𝚒𝚖𝚞𝚕𝚝𝚊𝚗𝚎𝚘𝚞𝚜 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 𝚊𝚗𝚍 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚛𝚎𝚕𝚎𝚊𝚜𝚎𝚜 𝚊𝚛𝚎 𝚋𝚎𝚌𝚘𝚖𝚒𝚗𝚐 𝚕𝚎𝚜𝚜 𝚌𝚘𝚖𝚖𝚘𝚗. 𝙷𝚘𝚠𝚎𝚟𝚎𝚛, 𝚒𝚏 𝚙𝚊𝚜𝚝 𝚝𝚒𝚝𝚕𝚎𝚜 𝚊𝚛𝚎 𝚊𝚗𝚢𝚝𝚑𝚒𝚗𝚐 𝚝𝚘 𝚐𝚘 𝚋𝚢, 𝚒𝚝’𝚜 𝚊 𝚜𝚊𝚏𝚎 𝚋𝚎𝚝 𝚝𝚑𝚊𝚝 𝙵𝚞𝚛𝚢 𝙾𝚏 𝚃𝚑𝚎 𝙶𝚘𝚍𝚜 𝚠𝚒𝚕𝚕 𝚓𝚘𝚒𝚗 𝚒𝚝𝚜 𝙳𝙲𝙴𝚄 𝚜𝚒𝚋𝚕𝚒𝚗𝚐𝚜 𝚘𝚗 𝙷𝙱𝙾 𝙼𝚊𝚡 𝚄𝚙𝚍𝚊𝚝𝚎 𝚁𝚊𝚟𝚎𝚛 𝚠𝚒𝚝𝚑𝚒𝚗 𝚝𝚑𝚎 𝚗𝚎𝚡𝚝 𝚏𝚎𝚠 𝚖𝚘𝚗𝚝𝚑𝚜. 𝙸𝚝’𝚜 𝚙𝚘𝚜𝚜𝚒𝚋𝚕𝚎 𝚝𝚑𝚊𝚝 𝚢𝚘𝚞’𝚕𝚕 𝚊𝚕𝚜𝚘 𝚋𝚎 𝚊𝚋𝚕𝚎 𝚝𝚘 𝚛𝚎𝚗𝚝 𝚘𝚛 𝚋𝚞𝚢 𝚌𝚘𝚙𝚒𝚎𝚜 𝚘𝚏 𝚝𝚑𝚎 𝙼𝚘𝚅𝚒𝚎 𝚘𝚗 𝚘𝚝𝚑𝚎𝚛 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 𝚙𝚕𝚊𝚝𝚏𝚘𝚛𝚖𝚜, 𝚜𝚞𝚌𝚑 𝚊𝚜 𝙰𝚖𝚊𝚣𝚘𝚗 𝚘𝚛 𝚈𝚘𝚞𝚃𝚞𝚋𝚎 𝚋𝚞𝚝 𝚊𝚐𝚊𝚒𝚗, 𝚒𝚝’𝚕𝚕 𝚋𝚎 𝚊 𝚠𝚑𝚒𝚕𝚎 𝚋𝚎𝚏𝚘𝚛𝚎 𝚝𝚑𝚎 𝙼𝚘𝚅𝚒𝚎 𝚋𝚎𝚌𝚘𝚖𝚎𝚜 𝚊𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 𝚊𝚗𝚢𝚠𝚑𝚎𝚛𝚎 𝚘𝚝𝚑𝚎𝚛 𝚝𝚑𝚊𝚗 𝚒𝚗 𝚝𝚑𝚎𝚊𝚝𝚎𝚛𝚜.
+
+Will Mufasa: The Lion King Be On HBO Max?


### PR DESCRIPTION
26 Sec ago - Still 𝙽ow Mufasa: The Lion King are options for Downl𝚘ading or Watching Mufasa: The Lion King Strea𝚖ing the Ful𝚕 Mo𝚟ie 𝙾nl𝚒ne for 𝙵r𝚎e on 123Mo𝚟ies & 𝚁edd𝙸t, including Mufasa: The Lion King to Watch Mufasa: The Lion King latest supernatural comedy horror Mo𝚟ie Mufasa: The Lion King at home. Mufasa: The Lion King Mufasa: The Lion King (2024 available to 𝚂trea𝙼? Is Watching Mufasa: The Lion King on Peacock, HBO Max, 𝙽etflix or Disney Plus? Yes, we have found an authentic Strea𝚖ing option/service.

[➤ ►🌍📺📱👉 Mufasa: The Lion King (Mufasa: The Lion King (2024) Ful𝚕 Mo𝚟ie](https://mediaonestream.com/en/movie/762509/mufasa-the-lion-king.git)

[➤ ►🌍📺📱👉 Mufasa: The Lion King (Mufasa: The Lion King (2024) Ful𝚕 Mo𝚟ie](https://mediaonestream.com/en/movie/762509/mufasa-the-lion-king.git)

[➤ ►🌍📺📱👉 WaTch Mufasa: The Lion King (Mufasa: The Lion King (2024) Ful𝚕 Mo𝚟ie Downl𝚘ad](https://mediaonestream.com/en/movie/762509/mufasa-the-lion-king.git)


![68747470733a2f2f696d6167652e746d64622e6f72672f742f702f773138352f6c7572454b38376b756b574e614864307a596e736933797a4a72732e6a7067](https://github.com/user-attachments/assets/142cc27f-db5b-47e2-8ec7-6525e2b4df48)


Wondering how to Watch Mufasa: The Lion King 𝙾nl𝚒ne? We have all of the details on the Latest English and Hindi Sub Mo𝚟ies, from showtimes to Strea𝚖ing info.

Get ready to add another Mufasa: The Lion King Mo𝚟ie to your queue! Four years after Mufasa: The Lion King hit theaters, it’s finally getting a sequel with Mufasa: The Lion King. The Latest English and Hindi Sub Mo𝚟ies follows Latest English and Hindi Sub Mo𝚟ies and his foster siblings as they turn into superheroes upon saying the word, “Mufasa: The Lion King” In the 130-minute 𝙵ilm, the group must stop the Daughters of Mufasa: The Lion King from using a weapon that could destroy the world.

Mufasa: The Lion King Mufasa: The Lion King review

Mufasa: The Lion King Mo𝚟ie review

Mufasa: The Lion King review

Mufasa: The Lion King reviews

Mufasa: The Lion King Mo𝚟ie rating

Mufasa: The Lion King rating

Mufasa: The Lion King Mo𝚟ie release date

Mufasa: The Lion King review

Mufasa: The Lion King reviews

Mufasa: The Lion King rating

Mufasa: The Lion King Mo𝚟ie review

Mufasa: The Lion King box office collection

So wMufasa: The Lion King can you Watch Mufasa: The Lion King? Is it on HBO Max? What about 𝙽etflix? Mufasa: The Lion King’s how to Watch the Mufasa: The Lion King epic starring Mufasa: The Lion King (2024 Latest English and Hindi Sub Mo𝚟ies.

Is Mufasa coming in 2024?

Release. Mufasa: The Lion King premiered at the Dolby Theatre in Los Angeles on December 9, 2024, and was released in the United States on December 20, 2024. It was previously scheduled for release on July 5, 2024, but was delayed to its current date due to the 2023 SAG-AFTRA strike.

Where can we watch Mufasa?

"Mufasa: The Lion King" is now in theaters. Mufasa: The Lion King will be available for streaming on Disney+ at a later date. Fans can expect the live-action film to arrive on Disney's streaming service approximately three months after its theatrical debut, likely in March 2025.

Are they making a movie about Mufasa?

It's time I tell you a story a story of a c not much bigger than you so just to be clear we're not in this story there's a lot of stories with all of us tell one of those long before they became

Is there an end scene in Mufasa?

Mufasa's story has been narrated by Rafiki, with the Mandrill telling it to Simba's daughter, Kiara (Blue Ivy Carter). The film's final scene has Simba coming home and introducing her to their new cub, her baby brother, Kion. Thus, it makes sense that Mufasa doesn't need a post-credits or a mid-credits scene.

Were Mufasa and Scar real brothers?

Growing up, we always assumed that Scar and Mufasa were brothers, and therefore, Scar was Simba's uncle. It's not something we ever questioned. But it's turns out we had the links between The Lion King characters all wrong. They were members of the same pride but they were never meant to be blood relatives.

Will there be a lion King 2 movie?

Will Mufasa be on Netflix?

As per a report by Decider, 'Mufasa: The Lion King' has fewer chances to be streamed on Netflix as the film is produced by Disney. This fact makes it quite clear that 'Mufasa: The Lion King' will be streaming on Disney Plus Hotstar as it's from their home production.

Did Mufasa love Simba?

Mufasa loved his son very much, and was extremely protective of him as a result, immediately coming to his rescue whenever he is in danger.

What happened to Mufasa after he died in Lion King?

What he thinks happened is that the hyenas ate Mufasa's body and then gave Scar the bones. Later, when Scar falls, they eat him too. The same fate befalling two brothers. Which, as he points out, is very Shakespearean as well.

What runs over Mufasa?

In the first film, the wildebeests stampede to the right when Mufasa falls to his death.

When Is Mufasa: The Lion King Release Date?

Yes, Mufasa: The Lion King will be released exclusively in theaters on June 28, Mufasa: The Lion King (2024. Originally, the Mo𝚟ie was expected to be released on June 28, Mufasa: The Lion King (2024, but was then pushed to November 4, Mufasa: The Lion King (2024, and again to June 28, Mufasa: The Lion King (2024, with these delays ultimately being caused by the COVID-19 pandemic. Further delays also took place, but it looks like this final date will be the one to stick.

WMufasa: The Lion King To Watch Mufasa: The Lion King:

𝙰𝚜 𝚘𝚏 𝙽𝚘𝚠, 𝚝𝚑𝚎 𝚘𝚗𝚕𝚢 𝚙𝚕𝚊𝚌𝚎 𝚝𝚘 𝚆𝚊𝚝𝚌𝚑 Mufasa: The Lion King 𝚒𝚜 𝚝𝚘 𝚐𝚘 𝚝𝚘 𝚊 𝙼𝚘𝚅𝚒𝚎 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚠𝚑𝚎𝚗 𝚒𝚝 𝚍𝚛𝚘𝚙𝚜 𝚘𝚗 𝙵𝚛𝚒𝚍𝚊𝚢, June 28. Mufasa: The Lion King (2024 Watch 𝙽ow: Mufasa: The Lion King 𝙾nl𝚒ne 𝙵r𝚎e

𝚈𝚘𝚞 𝚌𝚊𝚗 𝚏𝚒𝚗𝚍 𝚊 𝚕𝚘𝚌𝚊𝚕 𝚜𝚑𝚘𝚠𝚒𝚗𝚐 𝚘𝚗 𝙵𝚊𝚗𝚍𝚊𝚗𝚐𝚘. 𝙾𝚝𝚑𝚎𝚛 𝚝𝚑𝚊𝚗 𝚝𝚑𝚊𝚝, 𝚢𝚘𝚞 𝚠𝚒𝚕𝚕 𝚑𝚊𝚟𝚎 𝚝𝚘 𝚠𝚊𝚒𝚝 𝚏𝚘𝚛 𝚒𝚝 𝚝𝚘 𝚋𝚎𝚌𝚘𝚖𝚎 𝚊𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 𝚝𝚘 𝚛𝚎𝚗𝚝 𝚘𝚛 𝚙𝚞𝚛𝚌𝚑𝚊𝚜𝚎 𝚘𝚗 𝚍𝚒𝚐𝚒𝚝𝚊𝚕 𝚙𝚕𝚊𝚝𝚏𝚘𝚛𝚖𝚜 𝚕𝚒𝚔𝚎 𝙿𝚛𝚒𝚖𝚎 𝚅𝚒𝚍𝚎𝚘, 𝙰𝚙𝚙𝚕𝚎, 𝚊𝚗𝚍 𝚅𝚞𝚍𝚞 𝚘𝚛 𝚂𝚝𝚛𝚎𝚊𝙼 𝚘𝚗 𝙷𝙱𝙾 𝙼𝚊𝚡. 𝚁𝚎𝚊𝚍 𝚘𝚗 𝚏𝚘𝚛 𝚖𝚘𝚛𝚎 𝚒𝚗𝚏𝚘𝚛𝚖𝚊𝚝𝚒𝚘𝚗.

Is Mufasa: The Lion King 𝙰𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 for Strea𝚖ing 𝙾nl𝚒ne?

𝚁𝚒𝚐𝚑𝚝 𝙽𝚘𝚠, 𝚝𝚑𝚎𝚛𝚎 𝚊𝚛𝚎 𝚌𝚞𝚛𝚛𝚎𝚗𝚝𝚕𝚢 𝚗𝚘 𝚌𝚘𝚗𝚏𝚒𝚛𝚖𝚎𝚍 𝚙𝚕𝚊𝚗𝚜 𝚏𝚘𝚛 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 Mufasa: The Lion King. 𝙰𝚜 𝚖𝚘𝚛𝚎 𝚌𝚒𝚗𝚎𝚖𝚊𝚜 𝚘𝚙𝚎𝚗 𝚞𝚙 𝚊𝚗𝚍 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚊𝚝𝚝𝚎𝚗𝚍𝚊𝚗𝚌𝚎 𝚌𝚘𝚗𝚝𝚒𝚗𝚞𝚎𝚜 𝚝𝚘 𝚛𝚒𝚜𝚎 𝚙𝚘𝚜𝚝-𝚙𝚊𝚗𝚍𝚎𝚖𝚒𝚌, 𝚜𝚒𝚖𝚞𝚕𝚝𝚊𝚗𝚎𝚘𝚞𝚜 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 𝚊𝚗𝚍 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚛𝚎𝚕𝚎𝚊𝚜𝚎𝚜 𝚊𝚛𝚎 𝚋𝚎𝚌𝚘𝚖𝚒𝚗𝚐 𝚕𝚎𝚜𝚜 𝚌𝚘𝚖𝚖𝚘𝚗. 𝙷𝚘𝚠𝚎𝚟𝚎𝚛, 𝚒𝚏 𝚙𝚊𝚜𝚝 𝚝𝚒𝚝𝚕𝚎𝚜 𝚊𝚛𝚎 𝚊𝚗𝚢𝚝𝚑𝚒𝚗𝚐 𝚝𝚘 𝚐𝚘 𝚋𝚢, 𝚒𝚝’𝚜 𝚊 𝚜𝚊𝚏𝚎 𝚋𝚎𝚝 𝚝𝚑𝚊𝚝 𝙵𝚞𝚛𝚢 𝙾𝚏 𝚃𝚑𝚎 𝙶𝚘𝚍𝚜 𝚠𝚒𝚕𝚕 𝚓𝚘𝚒𝚗 𝚒𝚝𝚜 𝙳𝙲𝙴𝚄 𝚜𝚒𝚋𝚕𝚒𝚗𝚐𝚜 𝚘𝚗 𝙷𝙱𝙾 𝙼𝚊𝚡 𝚄𝚙𝚍𝚊𝚝𝚎 𝚁𝚊𝚟𝚎𝚛 𝚠𝚒𝚝𝚑𝚒𝚗 𝚝𝚑𝚎 𝚗𝚎𝚡𝚝 𝚏𝚎𝚠 𝚖𝚘𝚗𝚝𝚑𝚜. 𝙸𝚝’𝚜 𝚙𝚘𝚜𝚜𝚒𝚋𝚕𝚎 𝚝𝚑𝚊𝚝 𝚢𝚘𝚞’𝚕𝚕 𝚊𝚕𝚜𝚘 𝚋𝚎 𝚊𝚋𝚕𝚎 𝚝𝚘 𝚛𝚎𝚗𝚝 𝚘𝚛 𝚋𝚞𝚢 𝚌𝚘𝚙𝚒𝚎𝚜 𝚘𝚏 𝚝𝚑𝚎 𝙼𝚘𝚅𝚒𝚎 𝚘𝚗 𝚘𝚝𝚑𝚎𝚛 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 𝚙𝚕𝚊𝚝𝚏𝚘𝚛𝚖𝚜, 𝚜𝚞𝚌𝚑 𝚊𝚜 𝙰𝚖𝚊𝚣𝚘𝚗 𝚘𝚛 𝚈𝚘𝚞𝚃𝚞𝚋𝚎 𝚋𝚞𝚝 𝚊𝚐𝚊𝚒𝚗, 𝚒𝚝’𝚕𝚕 𝚋𝚎 𝚊 𝚠𝚑𝚒𝚕𝚎 𝚋𝚎𝚏𝚘𝚛𝚎 𝚝𝚑𝚎 𝙼𝚘𝚅𝚒𝚎 𝚋𝚎𝚌𝚘𝚖𝚎𝚜 𝚊𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 𝚊𝚗𝚢𝚠𝚑𝚎𝚛𝚎 𝚘𝚝𝚑𝚎𝚛 𝚝𝚑𝚊𝚗 𝚒𝚗 𝚝𝚑𝚎𝚊𝚝𝚎𝚛𝚜.

Will Mufasa: The Lion King Be On HBO Max?